### PR TITLE
More metrics

### DIFF
--- a/apmconnector/connector.go
+++ b/apmconnector/connector.go
@@ -3,8 +3,10 @@ package apmconnector
 import (
 	"context"
 	"fmt"
+
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.opentelemetry.io/collector/pdata/ptrace"
 	"go.uber.org/zap"
@@ -47,46 +49,86 @@ func (c *ApmConnector) Shutdown(context.Context) error {
 	return nil
 }
 
+func GetSdkLanguage(attributes pcommon.Map) string {
+	sdkLanguage, sdkLanguagePresent := attributes.Get("telemetry.sdk.language")
+	if sdkLanguagePresent {
+		return sdkLanguage.AsString()
+	}
+	return "unknown"
+}
+
 func ConvertTraces(logger *zap.Logger, td ptrace.Traces) pmetric.Metrics {
 	metrics := pmetric.NewMetrics()
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
 		rs := td.ResourceSpans().At(i)
 		rs.Resource().CopyTo(resourceMetrics.Resource())
-		sdkLanguage, sdkLanguagePresent := rs.Resource().Attributes().Get("telemetry.sdk.language")
+		sdkLanguage := GetSdkLanguage(rs.Resource().Attributes())
 		for j := 0; j < rs.ScopeSpans().Len(); j++ {
 			scopeSpan := rs.ScopeSpans().At(j)
 			scopeMetric := resourceMetrics.ScopeMetrics().AppendEmpty()
 			for k := 0; k < scopeSpan.Spans().Len(); k++ {
 				span := scopeSpan.Spans().At(k)
-				if span.Kind() != ptrace.SpanKindServer {
-					continue
+				if span.Kind() == ptrace.SpanKindServer {
+					ProcessServerSpan(span, scopeMetric, sdkLanguage)
+				} else if span.Kind() == ptrace.SpanKindClient {
+					// filter out db calls that have no parent (so no transaction)
+					if !span.ParentSpanID().IsEmpty() {
+						ProcessClientSpan(span, scopeMetric, sdkLanguage)
+					}
 				}
 
-				metric := AddMetric(scopeMetric.Metrics(), "apm.service.transaction.duration")
-				dp := SetHistogramFromSpan(span, metric)
-				span.Attributes().CopyTo(dp.Attributes())
-				dp.Attributes().PutStr("transactionType", "Web")
-				transactionName := GetTransactionMetricName(span)
-				dp.Attributes().PutStr("transactionName", transactionName)
-
-				overviewWeb := AddMetric(scopeMetric.Metrics(), "apm.service.overview.web")
-				overviewDp := SetHistogramFromSpan(span, overviewWeb)
-				span.Attributes().CopyTo(overviewDp.Attributes())
-				if sdkLanguagePresent {
-					overviewDp.Attributes().PutStr("segmentName", sdkLanguage.AsString())
-
-					txBreakdownMetric := AddMetric(scopeMetric.Metrics(), "apm.service.transaction.overview")
-					txBreakdownDp := SetHistogramFromSpan(span, txBreakdownMetric)
-					span.Attributes().CopyTo(txBreakdownDp.Attributes())
-					txBreakdownDp.Attributes().PutStr("metricTimesliceName", sdkLanguage.AsString())
-					txBreakdownDp.Attributes().PutStr("transactionName", transactionName)
-				}
+				/*
+					for key, value := range span.Attributes().AsRaw() {
+						fmt.Printf("%s value is %v\n", key, value)
+						logger.Info(key)
+						//			logger.Info(value)
+					}*/
 			}
 		}
 
 	}
 	return metrics
+}
+
+func ProcessClientSpan(span ptrace.Span, scopeMetric pmetric.ScopeMetrics, sdkLanguage string) {
+	dbSystem, dbSystemPresent := span.Attributes().Get("db.system")
+	if dbSystemPresent {
+		dbOperation, dbOperationPresent := span.Attributes().Get("db.operation")
+		if dbOperationPresent {
+			dbTable, dbTablePresent := span.Attributes().Get("db.sql.table")
+			if dbTablePresent {
+				metric := AddMetric(scopeMetric.Metrics(), "apm.service.datastore.operation.duration")
+				dp := SetHistogramFromSpan(span, metric)
+				span.Attributes().CopyTo(dp.Attributes())
+				dp.Attributes().PutStr("db.operation", dbOperation.AsString())
+				dp.Attributes().PutStr("db.system", dbSystem.AsString())
+				dp.Attributes().PutStr("db.sql.table", dbTable.AsString())
+			}
+		}
+	}
+}
+
+func ProcessServerSpan(span ptrace.Span, scopeMetric pmetric.ScopeMetrics, sdkLanguage string) {
+
+	metric := AddMetric(scopeMetric.Metrics(), "apm.service.transaction.duration")
+	dp := SetHistogramFromSpan(span, metric)
+	span.Attributes().CopyTo(dp.Attributes())
+	dp.Attributes().PutStr("transactionType", "Web")
+	transactionName := GetTransactionMetricName(span)
+	dp.Attributes().PutStr("transactionName", transactionName)
+
+	overviewWeb := AddMetric(scopeMetric.Metrics(), "apm.service.overview.web")
+	overviewDp := SetHistogramFromSpan(span, overviewWeb)
+	span.Attributes().CopyTo(overviewDp.Attributes())
+
+	overviewDp.Attributes().PutStr("segmentName", sdkLanguage)
+
+	txBreakdownMetric := AddMetric(scopeMetric.Metrics(), "apm.service.transaction.overview")
+	txBreakdownDp := SetHistogramFromSpan(span, txBreakdownMetric)
+	span.Attributes().CopyTo(txBreakdownDp.Attributes())
+	txBreakdownDp.Attributes().PutStr("metricTimesliceName", sdkLanguage)
+	txBreakdownDp.Attributes().PutStr("transactionName", transactionName)
 }
 
 func AddMetric(metrics pmetric.MetricSlice, metricName string) pmetric.Metric {

--- a/apmconnector/connector.go
+++ b/apmconnector/connector.go
@@ -62,6 +62,11 @@ func ConvertTraces(logger *zap.Logger, td ptrace.Traces) pmetric.Metrics {
 	for i := 0; i < td.ResourceSpans().Len(); i++ {
 		resourceMetrics := metrics.ResourceMetrics().AppendEmpty()
 		rs := td.ResourceSpans().At(i)
+		instrumentationProvider, instrumentationProviderPresent := rs.Resource().Attributes().Get("instrumentation.provider")
+		if instrumentationProviderPresent && instrumentationProvider.AsString() != "opentelemetry" {
+			logger.Debug("Skipping resource spans", zap.String("instrumentation.provider", instrumentationProvider.AsString()))
+			continue
+		}
 		rs.Resource().CopyTo(resourceMetrics.Resource())
 		sdkLanguage := GetSdkLanguage(rs.Resource().Attributes())
 		for j := 0; j < rs.ScopeSpans().Len(); j++ {

--- a/apmconnector/connector.go
+++ b/apmconnector/connector.go
@@ -77,13 +77,6 @@ func ConvertTraces(logger *zap.Logger, td ptrace.Traces) pmetric.Metrics {
 						ProcessClientSpan(span, scopeMetric, sdkLanguage)
 					}
 				}
-
-				/*
-					for key, value := range span.Attributes().AsRaw() {
-						fmt.Printf("%s value is %v\n", key, value)
-						logger.Info(key)
-						//			logger.Info(value)
-					}*/
 			}
 		}
 


### PR DESCRIPTION
This PR fills in the breakdown time on the summary overview and for transactions.  It's not a proper breakdown; I fill the entire time with `java` (or whatever the agent language is).  But it demonstrates another metric space we need to populate.

I also roughly implemented database metrics.